### PR TITLE
Add robots.txt pointing to sitemap

### DIFF
--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://myprompthive.com/sitemap.xml


### PR DESCRIPTION
Creates a robots.txt to allow all crawlers and reference the sitemap at /sitemap.xml.