### PR TITLE
Add GET /api/prompts endpoint stub

### DIFF
--- a/src/routes/prompts.js
+++ b/src/routes/prompts.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const router = express.Router();
+
+// GET /api/prompts
+router.get('/', (req, res) => {
+  // TODO: Fetch real prompts from DB or in-memory store
+  res.json({ prompts: [] });
+});
+
+module.exports = router;

--- a/src/server.js
+++ b/src/server.js
@@ -1,10 +1,16 @@
 const express = require('express');
 const app = express();
 const PORT = process.env.PORT || 3000;
+// Import the prompts router
+
+const promptsRouter = require('./routes/prompts');
 
 app.get('/', (req, res) => {
   res.send('PromptForge API is up and running!');
 });
+// Mount the prompts router
+
+app.use('/api/prompts', promptsRouter);
 
 app.listen(PORT, () => {
   console.log(`Server listening on port ${PORT}`);


### PR DESCRIPTION
Introduces a stubbed /api/prompts GET route returning an empty prompts array.