### PR TITLE
Wire GET /api/prompts to use in-memory promptModel

### DIFF
--- a/src/routes/prompts.js
+++ b/src/routes/prompts.js
@@ -1,10 +1,11 @@
 const express = require('express');
 const router = express.Router();
+const { getAllPrompts, addPrompt } = require('../models/promptModel');
 
 // GET /api/prompts
 router.get('/', (req, res) => {
-  // TODO: Fetch real prompts from DB or in-memory store
-  res.json({ prompts: [] });
+  const prompts = getAllPrompts();
+  res.json({ prompts });
 });
 
 module.exports = router;


### PR DESCRIPTION
Updates /api/prompts to fetch from promptModel.getAllPrompts() instead of returning an empty array.