### PR TITLE
Add POST /api/prompts endpoint to create new prompts

### DIFF
--- a/src/routes/prompts.js
+++ b/src/routes/prompts.js
@@ -8,4 +8,14 @@ router.get('/', (req, res) => {
   res.json({ prompts });
 });
 
+// POST /api/prompts
+router.post('/', express.json(), (req, res) => {
+    const { text } = req.body;
+    if (!text) {
+      return res.status(400).json({ error: 'Text field is required' });
+    }
+    const newPrompt = addPrompt({ text });
+    res.status(201).json(newPrompt);
+  });
+
 module.exports = router;


### PR DESCRIPTION
Implements a POST /api/prompts route that validates input and uses promptModel.addPrompt() to add prompts.